### PR TITLE
Use require package.json to read package version

### DIFF
--- a/packages/jbr/lib/task/ExperimentLoader.ts
+++ b/packages/jbr/lib/task/ExperimentLoader.ts
@@ -12,6 +12,7 @@ import type { Experiment } from '../experiment/Experiment';
 import type { ExperimentHandler } from '../experiment/ExperimentHandler';
 import type { HookHandler } from '../hook/HookHandler';
 import type { IExperimentPaths } from './ITaskContext';
+const pJson = require('../../package.json');
 
 /**
  * Loads and instantiates an experiment by config.
@@ -22,8 +23,8 @@ export class ExperimentLoader {
   public static readonly COMBINATIONS_NAME = 'jbr-combinations.json';
   public static readonly PACKAGEJSON_NAME = 'package.json';
   public static readonly PREPAREDMARKER_PATH = [ 'generated', '.prepared' ];
-  public static readonly IRI_EXPERIMENT_HANDLER = `https://linkedsoftwaredependencies.org/bundles/npm/jbr/^2.0.0/components/experiment/ExperimentHandler.jsonld#ExperimentHandler`;
-  public static readonly IRI_HOOK_HANDLER = `https://linkedsoftwaredependencies.org/bundles/npm/jbr/^2.0.0/components/hook/HookHandler.jsonld#HookHandler`;
+  public static readonly IRI_EXPERIMENT_HANDLER = `https://linkedsoftwaredependencies.org/bundles/npm/jbr/^${pJson.version}/components/experiment/ExperimentHandler.jsonld#ExperimentHandler`;
+  public static readonly IRI_HOOK_HANDLER = `https://linkedsoftwaredependencies.org/bundles/npm/jbr/^${pJson.version}/components/hook/HookHandler.jsonld#HookHandler`;
 
   private readonly componentsManager: ComponentsManager<any>;
 


### PR DESCRIPTION
When updating the package version, JBR wasn't able to find experiment and hook types due to outdated versions in IRIs. This PR dynamically updates the IRIs according to the JBR version in the package.json to prevent this.