### PR TITLE
Fix WatDiv query discovery and add newlines to experiment loggers

### DIFF
--- a/packages/experiment-solidbench/lib/ExperimentSolidBench.ts
+++ b/packages/experiment-solidbench/lib/ExperimentSolidBench.ts
@@ -197,7 +197,7 @@ export class ExperimentSolidBench implements Experiment {
       warmup: this.queryRunnerWarmupRounds,
       requestDelay: this.queryRunnerRequestDelay,
       availabilityCheckTimeout: this.queryRunnerEndpointAvailabilityCheckTimeout,
-      logger: (message: string) => process.stderr.write(message),
+      logger: (message: string) => process.stderr.write(`${message}\n`),
       additionalUrlParams: new URLSearchParams(this.queryRunnerUrlParams),
       timeout: this.queryTimeoutFallback,
     }).run({

--- a/packages/experiment-watdiv/lib/ExperimentWatDiv.ts
+++ b/packages/experiment-watdiv/lib/ExperimentWatDiv.ts
@@ -139,7 +139,7 @@ export class ExperimentWatDiv implements Experiment {
     // Determine query sets
     const queryLoader = new QueryLoaderFile({
       path: Path.join(context.experimentPaths.generated, 'queries'),
-      extensions: [ '.sparql' ],
+      extensions: [ '.txt' ],
     });
     let querySets = await queryLoader.loadQueries();
     if (context.filter) {

--- a/packages/experiment-watdiv/lib/ExperimentWatDiv.ts
+++ b/packages/experiment-watdiv/lib/ExperimentWatDiv.ts
@@ -157,7 +157,7 @@ export class ExperimentWatDiv implements Experiment {
       warmup: this.queryRunnerWarmupRounds,
       requestDelay: this.queryRunnerRequestDelay,
       availabilityCheckTimeout: this.queryRunnerEndpointAvailabilityCheckTimeout,
-      logger: (message: string) => process.stderr.write(message),
+      logger: (message: string) => process.stderr.write(`${message}\n`),
       additionalUrlParams: new URLSearchParams(this.queryRunnerUrlParams),
       timeout: this.queryTimeoutFallback,
     }).run({


### PR DESCRIPTION
Here is a small set of changes to:
1. Fix the issue with detecting WatDiv queries. They use `.txt` extension, which I completely missed. Sorry about that. :frowning_face: 
2. Add newlines to the logger functions in the experiments, because otherwise the output becomes unreadable.

I think these changes only require a minor bugfix release.