### PR TITLE
added '.rq' to the array of accepted query file extensions

### DIFF
--- a/packages/experiment-solidbench/lib/ExperimentSolidBench.ts
+++ b/packages/experiment-solidbench/lib/ExperimentSolidBench.ts
@@ -189,7 +189,7 @@ export class ExperimentSolidBench implements Experiment {
     // Set up the query loader
     const queryLoader = new QueryLoaderFile({
       path: Path.join(context.experimentPaths.generated, 'out-queries'),
-      extensions: [ '.sparql' ],
+      extensions: [ '.sparql', '.rq' ],
     });
 
     // Initiate SPARQL benchmark runner

--- a/packages/experiment-sparql-custom/lib/ExperimentSparqlCustom.ts
+++ b/packages/experiment-sparql-custom/lib/ExperimentSparqlCustom.ts
@@ -67,7 +67,7 @@ export class ExperimentSparqlCustom implements Experiment {
     // Determine query sets
     const queryLoader = new QueryLoaderFile({
       path: Path.join(context.experimentPaths.root, this.queriesPath),
-      extensions: [ '.txt', '.sparql' ],
+      extensions: [ '.txt', '.sparql', '.rq' ],
     });
     let querySets = await queryLoader.loadQueries();
     if (context.filter) {


### PR DESCRIPTION
Query files with the extension '.rq' are now recognized in the `experiment-solidbench` and `experiment-sparql-custom` packages. 