### PR TITLE
Resolve lint errors from eslint-config v1.2.0 (stacked on #52)

### DIFF
--- a/packages/experiment-bsbm/lib/ExperimentBsbm.ts
+++ b/packages/experiment-bsbm/lib/ExperimentBsbm.ts
@@ -86,6 +86,7 @@ export class ExperimentBsbm implements Experiment {
           ],
         },
         logFilePath: Path.join(context.experimentPaths.output, 'logs', 'bsbm-generation.txt'),
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       })).join();
     }
 
@@ -135,6 +136,7 @@ export class ExperimentBsbm implements Experiment {
     ], network);
 
     // Wait for the experiment driver to end
+    // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
     await testDriverHandler.join();
     stopEndpointStats();
 

--- a/packages/experiment-bsbm/lib/ExperimentHandlerBsbm.ts
+++ b/packages/experiment-bsbm/lib/ExperimentHandlerBsbm.ts
@@ -12,7 +12,7 @@ export class ExperimentHandlerBsbm extends ExperimentHandler<ExperimentBsbm> {
 
   public getDefaultParams(experimentPaths: IExperimentPaths): Record<string, any> {
     return {
-      productCount: 1000,
+      productCount: 1_000,
       generateHdt: false,
       endpointUrl: 'http://localhost:3001/sparql',
       endpointUrlExternal: 'http://localhost:3001/sparql',

--- a/packages/experiment-solid-session-bench/test/ExperimentSolidSessionBench.test.ts
+++ b/packages/experiment-solid-session-bench/test/ExperimentSolidSessionBench.test.ts
@@ -193,7 +193,7 @@ describe('ExperimentSolidSessionBench', () => {
     dirsOut = {};
     filesOut = {};
     (<any> process).on = jest.fn();
-    jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 8192 * 1024 * 1024 }));
+    jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 8_192 * 1_024 * 1_024 }));
   });
 
   describe('replaceBaseUrlInDir', () => {
@@ -256,7 +256,7 @@ describe('ExperimentSolidSessionBench', () => {
     });
 
     it('should warn when not enough memory for preparing', async() => {
-      jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 4096 * 1024 * 1024 }));
+      jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 4_096 * 1_024 * 1_024 }));
 
       await experiment.prepare(context, false);
 
@@ -321,7 +321,6 @@ This can be configured using Node's --max_old_space_size option.`);
       expect(endpointHandler.close).toHaveBeenCalled();
       expect(serverHandlerStopCollectingStats).toHaveBeenCalled();
       expect(endpointHandlerStopCollectingStats).toHaveBeenCalled();
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(resultSerializerSerialize).toHaveBeenCalledWith(Path.normalize('CWD/output/query-times.csv'), {});
       expect(resultSerializerRawSerialize).toHaveBeenCalledWith(
         Path.normalize('CWD/output/query-results-raw.json'), {},

--- a/packages/experiment-solidbench/lib/ExperimentSolidBench.ts
+++ b/packages/experiment-solidbench/lib/ExperimentSolidBench.ts
@@ -73,7 +73,7 @@ export class ExperimentSolidBench implements Experiment {
       if (entry.isFile()) {
         const file = Path.join(path, entry.name);
         await fs.writeFile(file, (await fs.readFile(file, 'utf8'))
-          .replace(/localhost:3000/ug, 'solidbench-server:3000'));
+          .replaceAll('localhost:3000', 'solidbench-server:3000'));
       } else if (entry.isDirectory()) {
         await this.replaceBaseUrlInDir(Path.join(path, entry.name));
       }
@@ -82,9 +82,8 @@ export class ExperimentSolidBench implements Experiment {
 
   public async prepare(context: ITaskContext, forceOverwriteGenerated: boolean): Promise<void> {
     // Validate memory limit
-    const minimumMemory = 8192;
-    // eslint-disable-next-line no-bitwise
-    const currentMemory = v8.getHeapStatistics().heap_size_limit / 1024 / 1024;
+    const minimumMemory = 8_192;
+    const currentMemory = v8.getHeapStatistics().heap_size_limit / 1_024 / 1_024;
     if (currentMemory < minimumMemory) {
       context.logger.warn(`SolidBench recommends allocating at least ${minimumMemory} MB of memory, while only ${currentMemory} was allocated.\nThis can be configured using Node's --max_old_space_size option.`);
     }

--- a/packages/experiment-solidbench/test/ExperimentSolidBench.test.ts
+++ b/packages/experiment-solidbench/test/ExperimentSolidBench.test.ts
@@ -190,7 +190,7 @@ describe('ExperimentSolidBench', () => {
     dirsOut = {};
     filesOut = {};
     (<any> process).on = jest.fn();
-    jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 8192 * 1024 * 1024 }));
+    jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 8_192 * 1_024 * 1_024 }));
   });
 
   describe('replaceBaseUrlInDir', () => {
@@ -253,7 +253,7 @@ describe('ExperimentSolidBench', () => {
     });
 
     it('should warn when not enough memory for preparing', async() => {
-      jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 4096 * 1024 * 1024 }));
+      jest.spyOn(v8, 'getHeapStatistics').mockImplementation(() => (<any>{ heap_size_limit: 4_096 * 1_024 * 1_024 }));
 
       await experiment.prepare(context, false);
 
@@ -318,7 +318,6 @@ This can be configured using Node's --max_old_space_size option.`);
       expect(endpointHandler.close).toHaveBeenCalled();
       expect(serverHandlerStopCollectingStats).toHaveBeenCalled();
       expect(endpointHandlerStopCollectingStats).toHaveBeenCalled();
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(resultSerializerSerialize).toHaveBeenCalledWith(Path.normalize('CWD/output/query-times.csv'), {});
       expect(resultSerializerRawSerialize).toHaveBeenCalledWith(
         Path.normalize('CWD/output/query-results-raw.json'), {},

--- a/packages/experiment-sparql-custom/test/ExperimentSparqlCustom.test.ts
+++ b/packages/experiment-sparql-custom/test/ExperimentSparqlCustom.test.ts
@@ -139,7 +139,6 @@ SELECT DISTINCT ?entity WHERE {
       expect(sparqlBenchmarkRun).toHaveBeenCalled();
       expect(endpointHandler.close).toHaveBeenCalled();
       expect(endpointHandlerStopCollectingStats).toHaveBeenCalled();
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(resultSerializerSerialize).toHaveBeenCalledWith(
         Path.normalize('CWD/output/query-times.csv'), {},
       );
@@ -180,7 +179,6 @@ SELECT DISTINCT ?entity WHERE {
       expect(sparqlBenchmarkRun).toHaveBeenCalled();
       expect(endpointHandler.close).toHaveBeenCalled();
       expect(endpointHandlerStopCollectingStats).toHaveBeenCalled();
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(resultSerializerSerialize).toHaveBeenCalledWith(
         Path.normalize('CWD/output/query-times.csv'), {},
       );
@@ -284,7 +282,6 @@ SELECT DISTINCT ?entity WHERE {
       expect(sparqlBenchmarkRun).toHaveBeenCalled();
       expect(endpointHandler.close).toHaveBeenCalled();
       expect(endpointHandlerStopCollectingStats).toHaveBeenCalled();
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(resultSerializerSerialize).toHaveBeenCalledWith(
         Path.normalize('CWD/output/query-times.csv'), {},
       );

--- a/packages/experiment-watdiv/lib/ExperimentWatDiv.ts
+++ b/packages/experiment-watdiv/lib/ExperimentWatDiv.ts
@@ -96,6 +96,7 @@ export class ExperimentWatDiv implements Experiment {
           ],
         },
         logFilePath: Path.join(context.experimentPaths.output, 'logs', 'watdiv-generation.txt'),
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       })).join();
     }
 

--- a/packages/experiment-watdiv/test/ExperimentWatDiv.test.ts
+++ b/packages/experiment-watdiv/test/ExperimentWatDiv.test.ts
@@ -346,7 +346,6 @@ describe('ExperimentWatDiv', () => {
       expect(sparqlBenchmarkRun).toHaveBeenCalled();
       expect(endpointHandler.close).toHaveBeenCalled();
       expect(endpointHandlerStopCollectingStats).toHaveBeenCalled();
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(resultSerializerSerialize).toHaveBeenCalledWith(
         Path.normalize('CWD/output/query-times.csv'), {},
       );
@@ -450,7 +449,6 @@ describe('ExperimentWatDiv', () => {
       expect(sparqlBenchmarkRun).toHaveBeenCalled();
       expect(endpointHandler.close).toHaveBeenCalled();
       expect(endpointHandlerStopCollectingStats).toHaveBeenCalled();
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(resultSerializerSerialize).toHaveBeenCalledWith(
         Path.normalize('CWD/output/query-times.csv'), {},
       );

--- a/packages/hook-docker/lib/HookHandlerDocker.ts
+++ b/packages/hook-docker/lib/HookHandlerDocker.ts
@@ -21,8 +21,8 @@ export class HookHandlerDocker extends HookHandler<HookDocker> {
       },
       additionalBinds: [],
       additionalBindsPrepare: [],
-      innerPort: 3000,
-      outerPort: 3000,
+      innerPort: 3_000,
+      outerPort: 3_000,
     };
   }
 

--- a/packages/hook-docker/test/HookDocker.test.ts
+++ b/packages/hook-docker/test/HookDocker.test.ts
@@ -46,7 +46,7 @@ describe('HookDocker', () => {
       [ '/generated/dataset.nt:/tmp/dataset.nt' ],
       [ '/input/file.js' ],
       3_001,
-      3000,
+      3_000,
     );
   });
 

--- a/packages/jbr/lib/cli/CliHelpers.ts
+++ b/packages/jbr/lib/cli/CliHelpers.ts
@@ -45,7 +45,6 @@ export async function wrapCommandHandler(
 
   // Create context
   const dockerode = new Dockerode(argv.dockerOptions ?
-    // eslint-disable-next-line no-sync
     JSON.parse(await fs.readFile(argv.dockerOptions, 'utf8')) :
     undefined);
   const context: ITaskContext = {
@@ -62,7 +61,6 @@ export async function wrapCommandHandler(
       networkCreator: new DockerNetworkCreator(dockerode),
       networkInspector: new DockerNetworkInspector(dockerode),
     },
-    // eslint-disable-next-line unicorn/no-process-exit
     closeExperiment: () => process.emit(<any>'SIGTERM'),
     cleanupHandlers: [],
     ...argv.breakpoints ? { breakpointBarrier } : {},

--- a/packages/jbr/lib/docker/DockerContainerCreator.ts
+++ b/packages/jbr/lib/docker/DockerContainerCreator.ts
@@ -28,7 +28,7 @@ export class DockerContainerCreator {
       AttachStdout: true,
       AttachStderr: true,
       HostConfig: {
-        ...options.hostConfig || {},
+        ...options.hostConfig,
         ...options.resourceConstraints?.toHostConfig(),
       },
     });

--- a/packages/jbr/lib/docker/DockerImageBuilder.ts
+++ b/packages/jbr/lib/docker/DockerImageBuilder.ts
@@ -21,7 +21,6 @@ export class DockerImageBuilder {
       context: options.cwd,
       src: [ options.dockerFile, ...options.auxiliaryFiles || [] ],
     }, {
-      // eslint-disable-next-line id-length
       t: options.imageName,
       buildargs: options.buildArgs,
       dockerfile: options.dockerFile,
@@ -37,8 +36,8 @@ export class DockerImageBuilder {
         },
       );
     });
-    if (output.length > 0 && output[output.length - 1].error) {
-      throw new Error(output[output.length - 1].error);
+    if (output.length > 0 && output.at(-1).error) {
+      throw new Error(output.at(-1).error);
     }
   }
 

--- a/packages/jbr/lib/docker/StaticDockerResourceConstraints.ts
+++ b/packages/jbr/lib/docker/StaticDockerResourceConstraints.ts
@@ -65,3 +65,4 @@ export interface IDockerMemoryConstraints {
    */
   limit?: string;
 }
+/* eslint-enable no-bitwise,id-length */

--- a/packages/jbr/lib/experiment/ProcessHandlerComposite.ts
+++ b/packages/jbr/lib/experiment/ProcessHandlerComposite.ts
@@ -26,6 +26,7 @@ export class ProcessHandlerComposite implements ProcessHandler {
 
   public async join(): Promise<void> {
     for (const handler of this.processHandlers) {
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       await handler.join();
     }
   }

--- a/packages/jbr/lib/process/CliProcessHandler.ts
+++ b/packages/jbr/lib/process/CliProcessHandler.ts
@@ -51,7 +51,7 @@ export class CliProcessHandler implements ProcessHandler {
 
       const timeout = setTimeout(() => {
         this.childProcess.kill('SIGKILL');
-      }, 3000);
+      }, 3_000);
       const promise = new Promise<void>((resolve, reject) => {
         this.childProcess.on('close', () => {
           clearTimeout(timeout);
@@ -97,7 +97,7 @@ export class CliProcessHandler implements ProcessHandler {
           out.write(`${stats.cpu},${stats.memory}\n`);
         }
       });
-    }, 1000);
+    }, 1_000);
 
     // Stop the interval and close the file when done
     return () => {

--- a/packages/jbr/lib/task/TaskInitialize.ts
+++ b/packages/jbr/lib/task/TaskInitialize.ts
@@ -95,13 +95,13 @@ export class TaskInitialize {
     // Create config
     const experimentIri = ExperimentLoader.getDefaultExperimentIri(this.experimentName);
     const hookNames = experimentType.getHookNames();
-    const hookEntries = hookNames.reduce<Record<string, any>>((acc, hookName) => {
-      acc[hookName] = {
+    const hookEntries: Record<string, any> = Object.fromEntries(hookNames.map(hookName => [
+      hookName,
+      {
         '@id': `${experimentIri}:${hookName}`,
         '@type': HookNonConfigured.name,
-      };
-      return acc;
-    }, {});
+      },
+    ]));
     const experimentPaths = createExperimentPaths(this.targetDirectory);
     const experimentConfig = {
       '@context': [

--- a/packages/jbr/lib/task/TaskSetHook.ts
+++ b/packages/jbr/lib/task/TaskSetHook.ts
@@ -54,13 +54,13 @@ export class TaskSetHook {
 
     // Prepare sub-hooks
     const subHookNames = handlerType.getSubHookNames();
-    const subHookEntries = subHookNames.reduce<Record<string, any>>((acc, hookName) => {
-      acc[hookName] = {
+    const subHookEntries: Record<string, any> = Object.fromEntries(subHookNames.map(hookName => [
+      hookName,
+      {
         '@id': `${experimentIri}:${hookName}`,
         '@type': HookNonConfigured.name,
-      };
-      return acc;
-    }, {});
+      },
+    ]));
 
     // Find hook
     TaskSetHook.getObjectPath(configPath, config, this.hookPathName);

--- a/packages/jbr/lib/util/HdtConverter.ts
+++ b/packages/jbr/lib/util/HdtConverter.ts
@@ -38,6 +38,7 @@ export class HdtConverter {
           ],
         },
         logFilePath: Path.join(this.context.experimentPaths.output, 'logs', `${this.scope}-hdt.txt`),
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       })).join();
 
       // Generate HDT index file
@@ -50,6 +51,7 @@ export class HdtConverter {
           ],
         },
         logFilePath: Path.join(this.context.experimentPaths.output, 'logs', `${this.scope}-hdt-index.txt`),
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       })).join();
     }
   }

--- a/packages/jbr/test/docker/DockerContainerHandler.test.ts
+++ b/packages/jbr/test/docker/DockerContainerHandler.test.ts
@@ -48,6 +48,7 @@ describe('DockerContainerHandler', () => {
       const onResolve = jest.fn();
       const onReject = jest.fn();
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await new Promise(setImmediate);
 
@@ -65,6 +66,7 @@ describe('DockerContainerHandler', () => {
       const onResolve = jest.fn();
       const onReject = jest.fn();
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await new Promise(setImmediate);
 
@@ -85,6 +87,7 @@ describe('DockerContainerHandler', () => {
       out.emit('end');
       await new Promise(setImmediate);
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await new Promise(setImmediate);
 
@@ -99,6 +102,7 @@ describe('DockerContainerHandler', () => {
       out.emit('error', new Error('DockerContainerHandler test error'));
       await new Promise(setImmediate);
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await new Promise(setImmediate);
 

--- a/packages/jbr/test/docker/DockerContainerHandler.test.ts
+++ b/packages/jbr/test/docker/DockerContainerHandler.test.ts
@@ -150,7 +150,6 @@ describe('DockerContainerHandler', () => {
 
       out.emit('end');
 
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`Docker container ID`, undefined);
     });
 
@@ -161,7 +160,6 @@ describe('DockerContainerHandler', () => {
 
       out.emit('error', new Error('my error'));
 
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`Docker container ID`, new Error('my error'));
     });
 
@@ -174,7 +172,6 @@ describe('DockerContainerHandler', () => {
       out.emit('error', new Error('my error'));
 
       expect(termHandler).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`Docker container ID`, undefined);
     });
 
@@ -187,7 +184,6 @@ describe('DockerContainerHandler', () => {
       out.emit('end');
 
       expect(termHandler).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`Docker container ID`, new Error('my error'));
     });
 

--- a/packages/jbr/test/docker/DockerNetworkHandler.test.ts
+++ b/packages/jbr/test/docker/DockerNetworkHandler.test.ts
@@ -29,6 +29,7 @@ describe('DockerNetworkHandler', () => {
 
   describe('join', () => {
     it('does nothing', async() => {
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       await handler.join();
     });
   });

--- a/packages/jbr/test/experiment/ProcessHandlerComposite.test.ts
+++ b/packages/jbr/test/experiment/ProcessHandlerComposite.test.ts
@@ -62,6 +62,7 @@ describe('ProcessHandlerComposite', () => {
 
   describe('join', () => {
     it('joins all sub handlers', async() => {
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       await handler.join();
       expect(subHandler1.join).toHaveBeenCalledTimes(1);
       expect(subHandler2.join).toHaveBeenCalledTimes(1);
@@ -71,6 +72,7 @@ describe('ProcessHandlerComposite', () => {
     it('with a single erroring handler stops further joins', async() => {
       subHandler2.join = jest.fn(() => Promise.reject(new Error('Fail sub handler 2')));
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       await expect(handler.join()).rejects.toThrowError('Fail sub handler 2');
 
       expect(subHandler1.join).toHaveBeenCalledTimes(1);

--- a/packages/jbr/test/process/CliProcessHandler.test.ts
+++ b/packages/jbr/test/process/CliProcessHandler.test.ts
@@ -140,7 +140,7 @@ describe('CliProcessHandler', () => {
   describe('startCollectingStats', () => {
     it('handles a valid stream', async() => {
       const stop = await handler.startCollectingStats();
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(2_000);
 
       expect(write).toHaveBeenCalledTimes(3);
       expect(write).toHaveBeenCalledWith(`cpu_percentage,memory\n`);
@@ -172,7 +172,6 @@ describe('CliProcessHandler', () => {
 
       childProcess.emit('close');
 
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`CLI process (123)`, undefined);
     });
 
@@ -183,7 +182,6 @@ describe('CliProcessHandler', () => {
 
       childProcess.emit('error', new Error('my error'));
 
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`CLI process (123)`, new Error('my error'));
     });
 
@@ -196,7 +194,6 @@ describe('CliProcessHandler', () => {
       childProcess.emit('error', new Error('my error'));
 
       expect(termHandler).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`CLI process (123)`, undefined);
     });
 
@@ -209,7 +206,6 @@ describe('CliProcessHandler', () => {
       childProcess.emit('end');
 
       expect(termHandler).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(termHandler).toHaveBeenCalledWith(`CLI process (123)`, new Error('my error'));
     });
 

--- a/packages/jbr/test/process/CliProcessHandler.test.ts
+++ b/packages/jbr/test/process/CliProcessHandler.test.ts
@@ -78,6 +78,7 @@ describe('CliProcessHandler', () => {
       const onResolve = jest.fn();
       const onReject = jest.fn();
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await singleTick();
 
@@ -95,6 +96,7 @@ describe('CliProcessHandler', () => {
       const onResolve = jest.fn();
       const onReject = jest.fn();
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await singleTick();
 
@@ -115,6 +117,7 @@ describe('CliProcessHandler', () => {
       childProcess.emit('close');
       await singleTick();
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await singleTick();
 
@@ -129,6 +132,7 @@ describe('CliProcessHandler', () => {
       childProcess.emit('error', new Error('CliProcessHandler test error'));
       await singleTick();
 
+      // eslint-disable-next-line unicorn/require-array-join-separator -- not an array join
       handler.join().then(onResolve, onReject);
       await singleTick();
 

--- a/packages/jbr/test/util/HttpAvailabilityLatch.test.ts
+++ b/packages/jbr/test/util/HttpAvailabilityLatch.test.ts
@@ -35,19 +35,16 @@ describe('HttpAvailabilityLatch', () => {
 
   describe('isEndpointAvailable', () => {
     it('returns true for a valid endpoint', async() => {
-      // eslint-disable-next-line no-undef
       jest.spyOn(globalThis, 'fetch').mockResolvedValue(<Response>{ ok: true });
       await expect(latch.isEndpointAvailable('http://localhost:8080/')).resolves.toBeTruthy();
     });
 
     it('returns false for an invalid endpoint', async() => {
-      // eslint-disable-next-line no-undef
       jest.spyOn(globalThis, 'fetch').mockResolvedValue(<Response>{ ok: false });
       await expect(latch.isEndpointAvailable('http://localhost:8080/')).resolves.toBeFalsy();
     });
 
     it('returns false for a hanging request', async() => {
-      // eslint-disable-next-line no-undef
       jest.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise<Response>(() => {
         // Do nothing
       }));
@@ -57,7 +54,6 @@ describe('HttpAvailabilityLatch', () => {
     });
 
     it('returns false for an erroring request', async() => {
-      // eslint-disable-next-line no-undef
       jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Endpoint fetch failed'));
       const available = latch.isEndpointAvailable('http://localhost:8080/');
       await expect(available).resolves.toBeFalsy();
@@ -66,14 +62,12 @@ describe('HttpAvailabilityLatch', () => {
 
   describe('sleepUntilAvailable', () => {
     it('returns true for a valid endpoint', async() => {
-      // eslint-disable-next-line no-undef
       jest.spyOn(globalThis, 'fetch').mockResolvedValue(<Response>{ ok: true });
       await expect(latch.sleepUntilAvailable(context, 'http://localhost:8080/')).resolves.toBe(undefined);
     });
 
     it('returns true for an endpoint that becomes available later', async() => {
       let ok = false;
-      // eslint-disable-next-line no-undef
       jest.spyOn(globalThis, 'fetch').mockImplementation(async() => <Response>({ ok }));
 
       const resolve = jest.fn();


### PR DESCRIPTION
Stacked on #52, so it does not disturb that PR's automerge.

⚠️ Note that **#52 is a minor bump** (`1.0.1 → 1.2.0`), not a major one, and it is superseded by **#59** (`1.0.1 → 3.1.0`). Both branch off the same `master` commit, so only one of the two lines is worth keeping. This PR handles the 1.x line; #76 handles the v3 line.

Unlike v3, v1.2.0 is still eslintrc-based, so the linter actually runs here — no config migration was needed.

## Changes

- Autofixes for `unicorn/numeric-separators-style` (22), `unicorn/prefer-at` (2), `unicorn/prefer-string-replace-all` (1), `unicorn/no-useless-fallback-in-spread` (1)
- Removed 25 `eslint-disable` comments that no longer suppress anything (`eslint-comments/no-unused-disable`)
- Added the `eslint-enable` directive required to pair the whole-file disable in `StaticDockerResourceConstraints.ts` — the `no-bitwise` / `id-length` suppression there is genuinely needed (byte-shift math), so it was kept rather than removed
- Replaced two `Array#reduce` accumulators with `Object.fromEntries` (`unicorn/prefer-object-from-entries`)
- Silenced `unicorn/require-array-join-separator` at its 17 call sites (see below)

## `unicorn/require-array-join-separator`

All 17 hits were calls to **`ProcessHandler.join()`** — the domain method that waits for a process to exit. There were no genuine array joins among them, and the rule's autofix rewrites them to `join(',')`, which passes an argument to a zero-argument method and fails to compile (`TS2554: Expected 0 arguments, but got 1`) in production code such as `ExperimentBsbm.ts`, `HdtConverter.ts` and `ProcessHandlerComposite.ts`.

Per your request these are now suppressed. I used a per-site `eslint-disable-next-line` at each of the 17 locations rather than turning the rule off repo-wide, so a real array join elsewhere would still be flagged.

## Status

- ✅ Lint clean — **72 → 0 errors**
- ✅ `tsc` clean
- ✅ 305 tests / 44 suites pass, 100% coverage thresholds met